### PR TITLE
在單行註解時，應該要允許首字為中文的註解

### DIFF
--- a/Sniffs/Commenting/FileCommentSniff.php
+++ b/Sniffs/Commenting/FileCommentSniff.php
@@ -49,7 +49,7 @@ class SMSTWJoomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_
     /**
      * The header comment parser for the current file.
      *
-     * @var PHP_CodeSniffer_Comment_Parser_ClassCommentParser
+     * @var PHP_CodeSniffer_CommentParser_ClassCommentParser
      */
     protected $commentParser = null;
 

--- a/Sniffs/Commenting/SingleCommentSniff.php
+++ b/Sniffs/Commenting/SingleCommentSniff.php
@@ -61,9 +61,10 @@ class SMSTWJoomla_Sniffs_Commenting_SingleCommentSniff implements PHP_CodeSniffe
 
 		/*
 		 * New lines should always start with an upper case letter unless
-		*    The line is a continuation of a complete sentence
-		*    The term is code and is case sensitive.(@todo)
-		*/
+		 * - The line is a continuation of a complete sentence
+		 * - The term is code and is case sensitive.(@todo)
+		 * - The term is Chinese
+		 */
 
 		if(isset($comment{3}) && $comment{3} != strtoupper($comment{3}))
 		{

--- a/Sniffs/Commenting/SingleCommentSniff.php
+++ b/Sniffs/Commenting/SingleCommentSniff.php
@@ -65,19 +65,19 @@ class SMSTWJoomla_Sniffs_Commenting_SingleCommentSniff implements PHP_CodeSniffe
 		 * - The term is code and is case sensitive.(@todo)
 		 * - The term is Chinese
 		 */
+		$firstCharacter = strlen($comment) > 3 ? mb_substr($comment, 3, 1, 'UTF8') : '';
 
-		if(isset($comment{3}) && $comment{3} != strtoupper($comment{3}))
+		if (!empty($firstCharacter) && 1 == strlen($firstCharacter) && !preg_match('/[A-Z]/', $firstCharacter))
 		{
 			// Comment does not start with an upper case letter
-
 			$previous = $phpcsFile->findPrevious(T_COMMENT, $stackPtr - 1);
 
-			if($tokens[$previous]['line'] == $tokens[$stackPtr]['line'] - 1)
+			if ($tokens[$previous]['line'] == $tokens[$stackPtr]['line'] - 1)
 			{
 				// There is a comment on the previous line.
 				$test = trim($tokens[$previous]['content']);
 
-				if('.' != substr($test, strlen($test) - 1))
+				if ('.' != substr($test, strlen($test) - 1))
 				{
 					// If the previous comment does not end with a full stop "." we
 					// assume a sentence spanned over multiple lines.

--- a/Sniffs/Files/LineEndings.php
+++ b/Sniffs/Files/LineEndings.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * SMSTWJoomla_Sniffs_Files_IncludingFileSniff.
+ *
+ * PHP version 5
+ *
+ * @version   CVS: $Id: IncludingFileSniff.php 244643 2007-10-22 23:11:56Z squiz $
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * SMSTWJoomla_Sniffs_Files_LineEndingsSniff.
+ *
+ * Checks that end of line characters are correct.
+ *
+ * @version   Release: @package_version@
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class SMSTWJoomla_Sniffs_Files_LineEndingsSniff implements PHP_CodeSniffer_Sniff
+{
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+		'CSS',
+	);
+
+	/**
+	 * The valid EOL character.
+	 *
+	 * @var string
+	 */
+	public $eolChar = '\n';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct()
+	{
+		// Windows platform use "\r\n" as newline character
+		if (preg_match('#^Windows#i', php_uname()))
+		{
+			$this->eolChar = '\r\n';
+		}
+	}
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register()
+	{
+		return array(T_OPEN_TAG);
+
+	}
+
+	/**
+	 * Processes this sniff, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in
+	 *                                        the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	{
+		// We are only interested if this is the first open tag.
+		if ($stackPtr !== 0)
+		{
+			if ($phpcsFile->findPrevious(T_OPEN_TAG, ($stackPtr - 1)) !== false)
+			{
+				return;
+			}
+		}
+
+		$found = $phpcsFile->eolChar;
+		$found = str_replace("\n", '\n', $found);
+		$found = str_replace("\r", '\r', $found);
+
+		if ($found !== $this->eolChar)
+		{
+			// Check for single line files without an EOL. This is a very special
+			// case and the EOL char is set to \n when this happens.
+			if ($found === '\n')
+			{
+				$tokens    = $phpcsFile->getTokens();
+				$lastToken = ($phpcsFile->numTokens - 1);
+
+				if ($tokens[$lastToken]['line'] === 1
+					&& $tokens[$lastToken]['content'] !== "\n")
+				{
+					return;
+				}
+			}
+
+			$error    = 'End of line character is invalid; expected "%s" but found "%s"';
+			$expected = $this->eolChar;
+			$expected = str_replace("\n", '\n', $expected);
+			$expected = str_replace("\r", '\r', $expected);
+			$data     = array(
+				$expected,
+				$found,
+			);
+
+			$phpcsFile->addError($error, $stackPtr, 'InvalidEOLChar', $data);
+		}
+
+	}
+}

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -7,12 +7,6 @@
 	<!-- Include some additional sniffs from the Generic standard -->
 	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod" />
 	<rule ref="Generic.Files.EndFileNewline" />
-	<!-- Use Unix newlines -->
-	<rule ref="Generic.Files.LineEndings">
-		<properties>
-			<property name="eolChar" value="\n" />
-		</properties>
-	</rule>
 	<!-- Lines can be 85 chars long, but never show errors -->
 	<rule ref="Generic.Files.LineLength">
 		<properties>


### PR DESCRIPTION
For #3 在單行註解時，應該要允許首字為中文的註解

追加: 在 Windows 平台允許 "\r\n" 的換行字元 (預設是只接受 Unix 的換行字元)
